### PR TITLE
[WIP] Streamlined Scope

### DIFF
--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -47,7 +47,7 @@ The JOSE specifications are very widely deployed and well supported technology c
 
 With these new use cases, there is an increased focus on adopting privacy-protecting cryptographic primitives.  While such primitives are still an active area of academic and applied research, the leading candidates introduce new patterns that are not currently supported by JOSE.  These new patterns are largely focused on two areas: supporting selective disclosure when presenting a credential and minimizing correlation through the use of Zero-Knowledge Proofs (ZKPs), instead of traditional signatures.
 
-There are a growing number of these cryptographic primitives which support selective disclosure while protecting privacy across multiple presentations.  Examples that have already been or are being deployed in the context of Verifiable Credentials are:
+There are a growing number of these cryptographic primitives that support selective disclosure while protecting privacy across multiple presentations.  Examples that have already been or are being deployed in the context of Verifiable Credentials are:
 
 * [CL Signatures](https://eprint.iacr.org/2012/562.pdf)
 * [IDEMIX](http://www.zurich.ibm.com/idemix)

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -58,7 +58,7 @@ There are a growing number of these cryptographic primitives which support selec
 * [U-Prove](https://www.microsoft.com/en-us/research/project/u-prove/)
 * [Spartan](https://github.com/microsoft/Spartan)
 
-All of these follow the same pattern of taking multiple claims (a.k.a., "attributes" or "messages" in the literature) and binding them together into an issued credential.  These are then later securely one-way transformed into a presentation, revealing potentially only a subset of the original claims as required or just proofs of the values.
+All of these follow the same pattern of taking multiple claims (a.k.a., "attributes" or "messages" in the literature) and binding them together into an issued credential.  These are then later securely one-way transformed into a presentation that reveals potentially only a subset of the original claims, predicate proofs of the claim values, or only proofs of knowledge of the claims.
 
 
 # Conventions and Definitions

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -90,7 +90,7 @@ Although there are multiple payloads, the protected header still represents the 
 
 It is recommended that payload-specific information is not included in the header and is handled outside of the cryptographic envelope.  This is to minimize any correlatable signals in the metadata, to prevent a verifier from categorizing based on header changes that may varry between multiple JWPs.
 
-The JWP protected header MUST have at minimum an `alg` that supports proofs with signing, prooving, and verifying processing steps.
+The JWP protected header MUST have at minimum an `alg` that supports proofs with signing, proving, and verifying processing steps.
 
 For example:
 ```json

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -52,6 +52,7 @@ There are a growing number of these cryptographic primitives which support selec
 * [CL Signatures](https://eprint.iacr.org/2012/562.pdf)
 * [IDEMIX](http://www.zurich.ibm.com/idemix)
 * [BBS+](https://github.com/mattrglobal/bbs-signatures)
+* [MerkleDisclosureProof2021](https://github.com/transmute-industries/merkle-disclosure-proof-2021)
 * [Mercural Signatures](https://eprint.iacr.org/2020/979)
 * [PS Signatures](https://eprint.iacr.org/2015/525.pdf)
 * [U-Prove](https://www.microsoft.com/en-us/research/project/u-prove/)

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -101,6 +101,8 @@ For example:
 
 Every JWP algorithm must include a digest method that is used to generate a hash of the base64url serialized protected header.  The protected header cannot be selectively disclosed and the digest value MUST be included in all proof values.
 
+In order to minimize linkability, the same protected header SHOULD be static across all JWPs for a given key or issuer.  All re-used headers MUST have the same base64url serialized value to avoid any non-deterministic JSON serialization, and the JWP algorithm's digest method MUST have a deterministic output for identical inputs.
+
 ## Payloads
 
 Payloads are always represented as an ordered array.  The mapping of which value is in which payload slot is out of scope of this specification.

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -105,7 +105,7 @@ In order to minimize linkability, the same protected header SHOULD be static acr
 
 ## Payloads
 
-Payloads are always represented as an ordered array.  The mapping of which value is in which payload slot is out of scope of this specification.
+Payloads are always represented and processed as individual octet strings and arranged in an ordered array when there are multiple.  All application context of the placement and encoding of each payload value is out of scope of this specification and should be well defined and documented by the application or other specifications.
 
 In order to support ZKPs, individual payloads cannot be serialized before they are passed into an algorithm implementation.  This enables the algorithms to accept and internally encode elliptic curve points, blinded values, plain numbers, membership keys, etc.  Implementations are therefore required to provide optional arguments for each payload such that the application can utilize these capabilities as needed.
 

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -109,7 +109,7 @@ Payloads are always represented and processed as individual octet strings and ar
 
 In order to support ZKPs, individual payloads cannot be serialized before they are passed into an algorithm implementation.  This enables the algorithms to accept and internally encode elliptic curve points, blinded values, plain numbers, membership keys, etc.  Implementations are therefore required to provide optional arguments for each payload such that the application can utilize these capabilities as needed.
 
-When selective disclosure preferences are applied, any one or more payloads may be hidden.  The position of other payloads does not change due to any preceeding ones being hidden - the resulting array will simply be sparse without the hidden payloads.
+Any one or more payloads may be non-disclosed in a JWP.  When a payload is not disclosed the position of other payloads does not change - the resulting array will simply be sparse and only contain the disclosed payloads.  The disclosed payloads will always be in same array positions in order to preserve any index-based references by the application across the whole JWP lifecycle.  How the sparse array is represented is specific to the serialization used.
 
 ## Proof
 
@@ -127,7 +127,7 @@ Like JWS, JWP supports both a Compact Serialization and a JSON Serialization.
 
 ## Compact Serialization
 
-The individually encoded payloads are concatenated with the `~` character to form an ordered delimited array. Any hidden payloads during a derivation are simply left blank, resulting in sequential `~~` characters such that all payload positions are preserved.
+The individually encoded payloads are concatenated with the `~` character to form an ordered delimited array. Any non-disclosed payloads are simply left blank, resulting in sequential `~~` characters such that all payload positions are preserved.
 
 The header, payloads, and proof are then concatenated with a `.` character to form the final compact serialization.
 
@@ -137,7 +137,7 @@ Example compact serialization:
 
 ## JSON Serialization
 
-Hidden payloads in the JSON serialization are represented with a `null` value.
+Non-disclosed payloads in the JSON serialization are represented with a `null` value.
 
 Example flattened JSON serialization:
 
@@ -157,6 +157,7 @@ Example flattened JSON serialization:
 
 * Requirements for supporting algorithms
 * Application interface for verification
+* Data minimization of the protected header
 
 # IANA Considerations
 

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -71,7 +71,7 @@ when, and only when, they appear in all capitals, as shown here.
 
 A _JSON Web Proof (JWP)_ is very similar to a JWS [@RFC7515], with the addition that it can contain multiple individual payloads instead of a singular one.  New JWP-supporting algorithms are then able to separate and act on the individual payloads contained within.
 
-In addition to the JWS `sign` and `verify` interactions, JWP also importantly adds a `proove` processing step for interaction with the algorithm to perform the selective disclosure and privacy preserving transformations.  This allows for multi-party interactions where a credential is issued from one party, derived by the prooving party, then presented to another verifying party.  While `sign` only occurs once to create a JWP, the `proove` and `verify` steps may be safely repeated when supported by the algorithm.
+In addition to the JWS `sign` and `verify` interactions, JWP also importantly adds a `prove` processing step for interaction with the algorithm to perform the selective disclosure and privacy preserving transformations.  This allows for multi-party interactions where a credential is issued from one party, derived by the prooving party, then presented to another verifying party.  While `sign` only occurs once to create a JWP, the `prove` and `verify` steps may be safely repeated when supported by the algorithm.
 
 The intent of JSON Web Proofs is to establish a common container format for multiple payloads that can be integrity-verified against a proof value.  It does not create or specify any cryptographic protocols,  interaction protocols, or custom options for algorithms with additional capabilities.
 
@@ -112,9 +112,9 @@ When selective disclosure preferences are applied, any one or more payloads may 
 
 The proof value is a binary octet string that is opaque to applications.  Individual proof-supporting algorithms are responsible for the contents and security of the proof value along with any required internal structures to it.
 
-Implementations will also be required to provide optional arguments for each payload as input into the `proove` step.  These arguments can be used for generating predicate proofs, linking options, etc.
+Implementations will also be required to provide optional arguments for each payload as input into the `prove` step.  These arguments can be used for generating predicate proofs, linking options, etc.
 
-Algorithms SHOULD generate a new un-correlatable proof value during the `proove` step.  A JWP may also be single-use, where correlation across multiple derivations is not a factor.
+Algorithms SHOULD generate a new un-correlatable proof value during the `prove` step.  A JWP may also be single-use, where correlation across multiple derivations is not a factor.
 
 # Serializations
 

--- a/draft-jmiller-json-web-proof.md
+++ b/draft-jmiller-json-web-proof.md
@@ -72,7 +72,7 @@ when, and only when, they appear in all capitals, as shown here.
 
 A _JSON Web Proof (JWP)_ is very similar to a JWS [@RFC7515], with the addition that it can contain multiple individual payloads instead of a singular one.  New JWP-supporting algorithms are then able to separate and act on the individual payloads contained within.
 
-In addition to the JWS `sign` and `verify` interactions, JWP also importantly adds a `prove` processing step for interaction with the algorithm to perform the selective disclosure and privacy preserving transformations.  This allows for multi-party interactions where a credential is issued from one party, derived by the prooving party, then presented to another verifying party.  While `sign` only occurs once to create a JWP, the `prove` and `verify` steps may be safely repeated when supported by the algorithm.
+In addition to the JWS `sign` and `verify` interactions, JWP also importantly adds a `prove` processing step for interaction with the algorithm to perform the selective disclosure and privacy preserving transformations.  This allows for multi-party interactions where a credential is issued from one party, held by another party, then used to generate and present proofs about the credential to another verifying party.  While `sign` only occurs when a JWP is being created, the `prove` and `verify` steps may be safely repeated on a signed JWP (when supported by the algorithm).
 
 The intent of JSON Web Proofs is to establish a common container format for multiple payloads that can be integrity-verified against a proof value.  It does not create or specify any cryptographic protocols,  interaction protocols, or custom options for algorithms with additional capabilities.
 


### PR DESCRIPTION
There are two significant things to note in this PR:
1. Renaming of the `derive` step and "derivation" to the `prove` step and generating proofs, to be more consistent with the usage of "proofs" elsewhere in the draft.
2. Removing all language regarding the mapping of what values are in which payload slot, leaving this to the application or a companion spec.

The result is a simpler spec that focuses strictly on the cryptographic container with pluggable proof algorithms. 