### PR TITLE
add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ draft-ietf-jose-json-web-proof.xml
 package-lock.json
 report.xml
 !requirements.txt
+.idea


### PR DESCRIPTION
this PR add the string `.idea` to the .gitignore file so that users of JetBrains IDEs won't be prompted to include their local settings in PRs.