### PR TITLE
Fix Typo and Correct Object Attribute in BBS signature computation

### DIFF
--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -293,7 +293,7 @@ Figure: Presentation JWP (compact serialization)
 
 ### Presentation Verification
 
-Verification of a presentation is done by the holder using the `ProofVerify` operation from [@!I-D.irtf-cfrg-bbs-signatures, Section 3.4.4].
+Verification of a presentation is done by the verifier using the `ProofVerify` operation from [@!I-D.irtf-cfrg-bbs-signatures, Section 3.4.4].
 
 This operation utilizes the issuer's public key as `PK`, the issuer protected header as `header`, the issuance proof as `signature`, the holder's presentation protected header as `ph`, and the payloads as `disclosed_messages`.
 

--- a/fixtures/bbs-fixtures.mjs
+++ b/fixtures/bbs-fixtures.mjs
@@ -21,7 +21,7 @@ const signature = await pairing.bbs.bls12381_sha256.sign({
     publicKey: keyPair.publicKey, 
     secretKey: keyPair.secretKey, 
     header: protectedHeader,
-    payloads: payloads
+    messages: payloads
 });
 
 await fs.writeFile("build/bbs-issuer-proof.base64url", encode(signature), {encoding: "UTF-8"});


### PR DESCRIPTION
Hello,
I have reviewed the updates, and everything looks good to me, except for two minor points that this PR addresses:

1. Fixing a typo in the file `draft-ietf-jose-json-proof-algorithms.md`
2. Fixing the BBS signature computation:

In the `bbs.fixtures.mjs` file, the BBS _sign_ function was called with an object containing a 'payloads' property. However, the _sign_ function is designed to accept input objects of type "BbsSignRequest", which require a 'messages' property. Providing an object with a 'payloads' property instead resulted in the 'messages' property being set to 'undefined'.

No issues were immediately visible because, the BBS scheme allows empty message arrays for signing operations. 
Internally, the 'sign' operation accessed the 'messages' property, which was "undefined". So basically, It successfully computed the signature over an empty array of messages.

If you test the current code as it is and pass to the function an empty array of payloads you will notice that it produces the same signature value. Additionally, if you set `verifySignature: true` in the _deriveProof_ function, the signature verification would fail, as the messages are correctly passed to the function in this case.
