### PR TITLE
Compact representation of a zero-length payload.

### DIFF
--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -387,11 +387,13 @@ Like JWS, JWP supports both a Compact Serialization and a JSON Serialization.
 
 The individually encoded payloads are concatenated with the `~` character to form an ordered delimited array. Any non-disclosed payloads are left blank, resulting in sequential `~~` characters such that all payload positions are preserved.
 
+A payload which is disclosed but which contains no data (i.e. a zero-length octet string) is encoded as a single `_` character of data, which is not a valid result from base64url-encoding a value.
+
 The headers, concatenated payloads, and proof value are then concatenated with a `.` character to form the final compact serialization.  The issued form will only contain one header and always have three `.` separated parts.  The presented form will always have four `.` separated parts, the issued header, followed by the protected header, then the payloads and the proof.
 
 ## JSON Serialization
 
-Non-disclosed payloads in the JSON serialization are represented with a `null` value in the `payloads` array.
+Non-disclosed payloads in the JSON serialization are represented with a `null` value in the `payloads` array. A zero-length payload is represented as a zero-length base64url encoded sequence, the empty string `""`.
 
 This example flattened JSON serialization shows the presentation form with both the issuer and presentation headers, and with the first and third payloads hidden.
 


### PR DESCRIPTION
Handle the special case of a zero-length payload in compact encoding, by using the invalid base64url encoded sequence "_".

Clarify that JSON encoding would use the more intuitive empty string rather than matching the compact representation.

There are currently no examples for this, as it is meant more to maintain consistency between the representations rather than to satisfy an identified use-case.

Fixes #101 