### PR TITLE
Add pointers to JPT/CPT

### DIFF
--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -176,38 +176,103 @@ IANA CBOR Web Token Claims Registry [@IANA.CWT] established by
 
 # Claims Header Parameter {#claimsDef}
 
-A JSON Proof Token or CBOR Proof Token assigns each payload a claim
-name.  Payloads MUST each have a negotiated and understood claim name
-within the application context.  The simplest solution to establish
-payload claim names is as an ordered array that aligns with the ordering
-of payload slots.  This claims array can be conveniently included in the
-Claims Header Parameter.
+The issuer of a JPT or CPT assigns each payload a named claim, or a
+selector to a subset of data within a named claim.  Payloads MUST each
+have a negotiated and understood claim name within the application
+context. The `claims` Header Parameter allows for the mapping of payload
+slots to claims (and claim subsets) to be expressed within the Issuer
+Header.
 
-The `claims` Header Parameter is an array listing the Claim Names
-corresponding to the JWP payload slots, in the same order as the payload
-slots.  Each array value is a Claim Name, as defined in [@!RFC7519] or
-[@!RFC8392].  Use of this Header Parameter is OPTIONAL.
+The `claims` Header Parameter is an array of ordered elements, where
+each element is either a claim name, or selects some subset of a named
+claim. Use of this Header Parameter is OPTIONAL.
 
-All JPT payloads that are claim values MUST be the base64url encoding of
-the UTF-8 representation of a JSON value.  That said, predicate proofs
-derived from payload values are not represented as claims; they are
-contained in the presentation proof using algorithm-specific
-representations.
+An element value which is a string (or integer for CPT) indicates the
+claim name of the payload slot. For JPT, the corresponding payload MUST
+be the UTF-8 JSON Text containing the claim value, or a zero length
+payload if there is no corresponding claim value. For CPT, the
+corresponding payload MUST be the CBOR containing the claim value, or a
+zero length payload if there is no corresponding claim value.
 
-All CPT payloads that are claim values MUST be a CBOR value.  Likewise,
-CPT predicate proofs derived from payload values are not represented as
-claims; they are contained in the presentation proof using
+The claim mechanism is meant to disclose issuer-specified values.
+Predicate proofs derived from payload values are not represented as
+claims; they are instead contained in the presentation proof using
 algorithm-specific representations.
 
-The following is an example Issuer Header that includes a
+## Claims Path Selector
+
+This syntax is purposely meant to align with [DCQL], [SD-JWT-VC], and
+[CBOR-POINTER].
+
+A selector is represented as an array, where each element in sequence
+represents a rule for selecting a subset of a data item in context.
+Unlike selectors as defined in [CSS] and [JSONPATH], the syntax and
+processing are purposefully limited to prevent issues with forward
+traversal, and to limit implementation complexity.
+
+There are four limitations to traversal to allow for efficient forward
+traversal and implementation:
+
+1. Evaluation of a rule can only return either children of the data item
+or a calculated string, integer, or boolean result.
+
+2. Only one rule per expression is allowed to return multiple children.
+
+3. No support is provided for expressions or functions with arguments
+
+4. No nesting or operation precedence rules.
+
+The goal is to allow for disclosure of a subset of claims (or
+information about a claim) to prove a credential matches a query, while
+the query language the application uses is out of scope.
+
+The selector is evaluated against a context, which is either a JSON
+value or CBOR data item. Each element in the selector array corresponds
+to a rule, which will evaluate against the current context and either
+return a new context or fail. If evaluation of a rule fails, further
+rules in the selector will also fail.
+
+The initial context for the selector is a JSON object or CBOR map
+containing all named claims and their values. The following describes
+the evaluation of rules based on the current context:
+
+- For a CBOR Map or JSON Object, the rule specifies a key. For JSON,
+the rule MUST represented as a string. For CBOR, the rule is allowed to
+be any CBOR data item. On match, the context changes to the value
+specified by the key.
+
+- For a CBOR or JSON Array, there are two rules defined:
+
+  1. If the rule is a positive integer, it is selecting a particular
+  index of the array. The context changes to the value at that index
+  2. If the rule is `null`, it is describing an evaluation over all
+  values in the array as described below.
+
+  For a `null` rule, the implementation should evaluate the remainder of
+  the rules against the value of each index. Each evaluation will result
+  in either a CBOR data item/JSON value, or a failure to evaluate based
+  on the rules. The data items should be combined into an array and
+  returned as the result of this evaluation.
+
+  When evaluating against each value in the array, the implementation MUST
+  NOT allow an additional evaluation against all values.
+
+- For a CBOR tag, a matching positive integer will return the untagged
+data item.
+
+There are no rules currently which evaluate against other data items/values.
+
+The following is an example JSON-formatted Issuer Header that includes a
 claims property:
 
 <{{./fixtures/template/jpt-issuer-header-with-claims.json}}
 
 In this example, the "iat" and "exp" would be JSON-formatted numbers,
 "family_name", "given_name" and "email" would be JSON strings (in
-quotes), "address" would be a JSON object, and "age_over_21" would be
-either `true` or `false`.
+quotes), "addresses" would be a JSON array containing at least two JSON
+objects,
+and "age_equal_or_over" would be A JSON object containing at least a key
+21 and corresponding value of either `true` or `false`.
 
 # Claims ID ("cid") Header Parameter {#cidDef}
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -177,7 +177,7 @@ IANA CBOR Web Token Claims Registry [@IANA.CWT] established by
 # Claims Header Parameter {#claimsDef}
 
 The issuer of a JPT or CPT assigns each payload a named claim, or a
-selector to a subset of data within a named claim.  Payloads MUST each
+pointer to a subset of data within a named claim.  Payloads MUST each
 have a negotiated and understood claim name within the application
 context. The `claims` Header Parameter allows for the mapping of payload
 slots to claims (and claim subsets) to be expressed within the Issuer
@@ -199,70 +199,54 @@ Predicate proofs derived from payload values are not represented as
 claims; they are instead contained in the presentation proof using
 algorithm-specific representations.
 
-## Claims Path Selector
+## Claims Path Pointer
 
 This syntax is purposely meant to align with [DCQL], [SD-JWT-VC], and
 [CBOR-POINTER].
 
-A selector is represented as an array, where each element in sequence
-represents a rule for selecting a subset of a data item in context.
-Unlike selectors as defined in [CSS] and [JSONPATH], the syntax and
-processing are purposefully limited to prevent issues with forward
-traversal, and to limit implementation complexity.
+A Claims Path Pointer is used to disclose a subset of a claim. This
+allows for claim to be declared as having structured information (such
+as a mailing address or transcript), while still allowing for only a
+subset of the information needed to be disclosed.
 
-There are four limitations to traversal to allow for efficient forward
-traversal and implementation:
+The pointer is evaluated against a context, which is either a JSON
+value or CBOR data item representing all claims. The result of the
+pointer is a JSON value or CBOR data item, or a failure if no such data
+item is available. For the purpose of representation in a payload, a
+failure is represented as a zero-length octet string.
 
-1. Evaluation of a rule can only return either children of the data item
-or a calculated string, integer, or boolean result.
+A pointer is represented as an array, where each element in sequence
+represents a pathspec for selecting a subset of a data item in context.
+Unlike selectors in [CSS] and expression languages like [JSONPATH], the
+syntax is purposefully restricted to aid in implementation, and to
+prevent attacker-chosen pointers from causing unexpectedly high runtime
+resource usage.
 
-2. Only one rule per expression is allowed to return multiple children.
+Each pathspec element is evaluated in sequence, and will select either
+a new value/data item or fail. The resulting value/data item is then
+evaluated against the next pathspec element until evaluation completes.
+If evaluation of a pathspec fails, further evaluation is aborted.
 
-3. No support is provided for expressions or functions with arguments
+Evaluation is dependent on the type of value or data item currently
+in context.
 
-4. No nesting or operation precedence rules.
+1. For a CBOR Map or JSON Object the pathspec defines an exact match
+against the key. For JSON, the pathspec MUST represented as a string.
+For CBOR, the pathspec is any valid CBOR data item. On match, the result
+is the value associated with the matched key.
 
-The goal is to allow for disclosure of a subset of claims (or
-information about a claim) to prove a credential matches a query, while
-the query language the application uses is out of scope.
+2. For a CBOR or JSON array, the pathspec MUST be a non-negative integer
+corresponding to the zero-based index of the array. On match, the result
+is the value at the corresponding array index. Indexes outside the
+bounds of the array are considered normal failures.
 
-The selector is evaluated against a context, which is either a JSON
-value or CBOR data item. Each element in the selector array corresponds
-to a rule, which will evaluate against the current context and either
-return a new context or fail. If evaluation of a rule fails, further
-rules in the selector will also fail.
+3. For a CBOR tag, a matching non-negative integer will return the
+untagged data item.
 
-The initial context for the selector is a JSON object or CBOR map
-containing all named claims and their values. The following describes
-the evaluation of rules based on the current context:
+There are no rules currently which evaluate against other CBOR data
+items.
 
-- For a CBOR Map or JSON Object, the rule specifies a key. For JSON,
-the rule MUST represented as a string. For CBOR, the rule is allowed to
-be any CBOR data item. On match, the context changes to the value
-specified by the key.
-
-- For a CBOR or JSON Array, there are two rules defined:
-
-  1. If the rule is a positive integer, it is selecting a particular
-  index of the array. The context changes to the value at that index
-  2. If the rule is `null`, it is describing an evaluation over all
-  values in the array as described below.
-
-  For a `null` rule, the implementation should evaluate the remainder of
-  the rules against the value of each index. Each evaluation will result
-  in either a CBOR data item/JSON value, or a failure to evaluate based
-  on the rules. The data items should be combined into an array and
-  returned as the result of this evaluation.
-
-  When evaluating against each value in the array, the implementation MUST
-  NOT allow an additional evaluation against all values.
-
-- For a CBOR tag, a matching positive integer will return the untagged
-data item.
-
-There are no rules currently which evaluate against other data items/values.
-
-The following is an example JSON-formatted Issuer Header that includes a
+The following is an example JSON-formatted Issuer Header containing a
 claims property:
 
 <{{./fixtures/template/jpt-issuer-header-with-claims.json}}

--- a/fixtures/template/cpt-issuer-header.edn
+++ b/fixtures/template/cpt-issuer-header.edn
@@ -13,8 +13,9 @@
     179,    / "email"       (I-D.maldant-spice-oidc-cwt TBD10) /
     ["addresses", 0], / no array variant defined.              /
     ["addresses", 1], / no array variant defined.              /
-    ["addresses", null, 6 ], / countries                       /
-    ["age_equal_or_over", 21]
+    ["addresses", 0, 6 ], / country 0                          /
+    ["addresses", 1, 6 ], / country 1                          /
+    ["age_equal_or_over", 21] / age_equal_or_over_21 /
   ],
   
   8: {      / iek /

--- a/fixtures/template/cpt-issuer-header.edn
+++ b/fixtures/template/cpt-issuer-header.edn
@@ -4,14 +4,19 @@
   3: 20,    / typ: "JPT" (20CPA) /
   5: "https://issuer.example",  / iss: "https://issuer.example" /
   6: [      / claims /
+    7,      / "cti" /
     6,      / "iat" /
-    4,      / "exp" / 
-    170,    / "family_name" (I-D.maldant-spice-oidc-cwt TBD1) /
-    171,    / "given_name"  (I-D.maldant-spice-oidc-cwt TBD2) / 
+    4,      / "exp" /
+    2,      / "sub" / 
+    170,    / "family_name" (I-D.maldant-spice-oidc-cwt TBD1)  /
+    171,    / "given_name"  (I-D.maldant-spice-oidc-cwt TBD2)  / 
     179,    / "email"       (I-D.maldant-spice-oidc-cwt TBD10) /
-    187,    / "address"     (I-D.maldant-spice-oidc-cwt TBD18) /
-    "age_over_21"
+    ["addresses", 0], / no array variant defined.              /
+    ["addresses", 1], / no array variant defined.              /
+    ["addresses", null, 6 ], / countries                       /
+    ["age_equal_or_over", 21]
   ],
+  
   8: {      / iek /
     1: 2,   / kty : "EC2" /
     -1: 1,  / crv: "P-256" /

--- a/fixtures/template/cpt-issuer-payloads.edn
+++ b/fixtures/template/cpt-issuer-payloads.edn
@@ -1,10 +1,12 @@
 [ / payloads    /
+  / cti         / h'e7d5785d1fa042bfaadb7a7d9880aa2a',
   / iat         / 171452160,
   / exp         / 171719999,
+  / sub         / "1000723",
   / family_name / "Doe",
   / given_name  / "Jay",
   / email       / "jaydoe@example.org",
-  / address     / {
+  / address 0   / {
     / formatted / 1: "1234 Main St.\nAnytown, CA 12345\nUSA",
     / street    / 2: "1234 Main St.",
     / locality  / 3: "Anytown",
@@ -12,5 +14,14 @@
     / post code / 5: "90210",
     / country   / 6: "USA"
   },
-  / age_over_21 / true
+  / address 1.  / {
+    / formatted / 1: "18995 Sycamore Dr.\nAnytown, CA 12346\nUSA",
+    / street    / 2: "18995 Sycamore Dr",
+    / locality  / 3: "Anytown",
+    / region.   / 4: "CA",
+    / post code / 5: "12346",
+    / country   / 6: "USA"
+  },
+  / addrs co.   / [ "USA", "USA"],
+  / age over 21 / true
 ]

--- a/fixtures/template/cpt-issuer-payloads.edn
+++ b/fixtures/template/cpt-issuer-payloads.edn
@@ -22,6 +22,7 @@
     / post code / 5: "12346",
     / country   / 6: "USA"
   },
-  / addrs co.   / [ "USA", "USA"],
+  "USA",
+  "USA",
   / age over 21 / true
 ]

--- a/fixtures/template/jpt-issuer-header-with-claims.json
+++ b/fixtures/template/jpt-issuer-header-with-claims.json
@@ -1,13 +1,18 @@
 {
   "alg": "BBS",
   "claims": [
+    "jti",
     "iat",
     "exp",
+    "sub",
     "family_name",
     "given_name",
     "email",
-    "address",
-    "age_over_21"
+    "addresses",
+    ["addresses", 0],
+    ["addresses", 1],
+    ["addresses", null, "country"],
+    ["age_equal_or_over", "21"]
   ],
   "kid": "HjfcpyjuZQ-O8Ye2hQnNbT9RbbnrobptdnExR0DUjU8"
 }

--- a/fixtures/template/jpt-issuer-header-with-claims.json
+++ b/fixtures/template/jpt-issuer-header-with-claims.json
@@ -11,7 +11,8 @@
     "addresses",
     ["addresses", 0],
     ["addresses", 1],
-    ["addresses", null, "country"],
+    ["addresses", 0, "country"],
+    ["addresses", 1, "country"],
     ["age_equal_or_over", "21"]
   ],
   "kid": "HjfcpyjuZQ-O8Ye2hQnNbT9RbbnrobptdnExR0DUjU8"

--- a/fixtures/template/jpt-issuer-payloads.json
+++ b/fixtures/template/jpt-issuer-payloads.json
@@ -22,6 +22,7 @@
         "postal_code": 12346,
         "country": "USA"
     },
-    ["USA", "USA"],
+    "USA",
+    "USA",
     true
 ]

--- a/fixtures/template/jpt-issuer-payloads.json
+++ b/fixtures/template/jpt-issuer-payloads.json
@@ -1,16 +1,27 @@
 [
-  1714521600,
-  1717199999,
-  "Doe",
-  "Jay",
-  "jaydoe@example.org",
-  {
-    "country": "USA",
-    "formatted": "1234 Main St.\nAnytown, CA 12345\nUSA",
-    "locality": "Anytown",
-    "postal_code": 12345,
-    "region": "CA",
-    "street_address": "1234 Main St."
-  },
-  true
+    "e7d5785d-1fa0-42bf-aadb-7a7d9880aa2a",
+    1714521600,
+    1717199999,
+    "1000723",
+    "Doe",
+    "Jay",
+    "jaydoe@example.org",
+    {
+        "formatted": "1234 Main St.\nAnytown, CA 12345\nUSA",
+        "street_address": "1234 Main St.",
+        "locality": "Anytown",
+        "region": "CA",
+        "postal_code": 12345,
+        "country": "USA"        
+    },
+    {
+        "formatted": "18995 Sycamore Dr.\nAnytown, CA 12346\nUSA",
+        "street_address": "18995 Sycamore Dr",
+        "locality": "Anytown",
+        "region": "CA",
+        "postal_code": 12346,
+        "country": "USA"
+    },
+    ["USA", "USA"],
+    true
 ]

--- a/fixtures/template/jpt-issuer-payloads.json
+++ b/fixtures/template/jpt-issuer-payloads.json
@@ -1,28 +1,28 @@
 [
-    "e7d5785d-1fa0-42bf-aadb-7a7d9880aa2a",
-    1714521600,
-    1717199999,
-    "1000723",
-    "Doe",
-    "Jay",
-    "jaydoe@example.org",
-    {
-        "formatted": "1234 Main St.\nAnytown, CA 12345\nUSA",
-        "street_address": "1234 Main St.",
-        "locality": "Anytown",
-        "region": "CA",
-        "postal_code": 12345,
-        "country": "USA"        
-    },
-    {
-        "formatted": "18995 Sycamore Dr.\nAnytown, CA 12346\nUSA",
-        "street_address": "18995 Sycamore Dr",
-        "locality": "Anytown",
-        "region": "CA",
-        "postal_code": 12346,
-        "country": "USA"
-    },
-    "USA",
-    "USA",
-    true
+  "e7d5785d-1fa0-42bf-aadb-7a7d9880aa2a",
+  1714521600,
+  1717199999,
+  "1000723",
+  "Doe",
+  "Jay",
+  "jaydoe@example.org",
+  {
+    "country": "USA",
+    "formatted": "1234 Main St.\nAnytown, CA 12345\nUSA",
+    "locality": "Anytown",
+    "postal_code": 12345,
+    "region": "CA",
+    "street_address": "1234 Main St."
+  },
+  {
+    "country": "USA",
+    "formatted": "18995 Sycamore Dr.\nAnytown, CA 12346\nUSA",
+    "locality": "Anytown",
+    "postal_code": 12346,
+    "region": "CA",
+    "street_address": "18995 Sycamore Dr"
+  },
+  "USA",
+  "USA",
+  true
 ]

--- a/scripts/lint-fixtures.mjs
+++ b/scripts/lint-fixtures.mjs
@@ -100,6 +100,57 @@ function canonicalizeJSON(value) {
     return value;
 }
 
+function formatInlineJSON(value) {
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return "[]";
+        }
+        return `[${value.map((item) => formatInlineJSON(item)).join(", ")}]`;
+    }
+    if (isPlainObject(value)) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) {
+            return "{}";
+        }
+        const entries = keys.map((key) => `${JSON.stringify(key)}: ${formatInlineJSON(value[key])}`);
+        return `{ ${entries.join(", ")} }`;
+    }
+    return JSON.stringify(value);
+}
+
+function formatCanonicalJSON(value, indent = 0, lineWidth = 76) {
+    const inline = formatInlineJSON(value);
+    if (indent + inline.length <= lineWidth) {
+        return inline;
+    }
+
+    const nestedIndent = indent + 2;
+    const indentText = " ".repeat(indent);
+    const nestedIndentText = " ".repeat(nestedIndent);
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return "[]";
+        }
+        const lines = value.map((item) => `${nestedIndentText}${formatCanonicalJSON(item, nestedIndent, lineWidth)}`);
+        return `[\n${lines.join(",\n")}\n${indentText}]`;
+    }
+
+    if (isPlainObject(value)) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) {
+            return "{}";
+        }
+        const lines = keys.map(
+            (key) =>
+                `${nestedIndentText}${JSON.stringify(key)}: ${formatCanonicalJSON(value[key], nestedIndent, lineWidth)}`
+        );
+        return `{\n${lines.join(",\n")}\n${indentText}}`;
+    }
+
+    return JSON.stringify(value);
+}
+
 async function collectTemplateJSONFindings() {
     const findings = [];
     const entries = await readdir(templateDir, { withFileTypes: true });
@@ -120,8 +171,10 @@ async function collectTemplateJSONFindings() {
             continue;
         }
 
-        const canonical = JSON.stringify(canonicalizeJSON(parsed), null, 2);
-        if (text !== canonical) {
+        const canonicalized = canonicalizeJSON(parsed);
+        const canonicalMultiline = JSON.stringify(canonicalized, null, 2);
+        const canonicalWithInlineCollections = formatCanonicalJSON(canonicalized);
+        if (text !== canonicalMultiline && text !== canonicalWithInlineCollections) {
             findings.push(`${relPath}: non-canonical JSON formatting/key order`);
         }
     }


### PR DESCRIPTION
Closes #186 

First pass at trying to define a path/pointer syntax that meets the requirements I've heard so far:

1. mirrors DCQL and SD-JWT-VC as closely as possible
2. keeps a way to select parts of an array of values
3. defines a CBOR equivalent which attempts to align with [CBOR Pointer](https://www.ietf.org/archive/id/draft-mahy-cbor-pointer-00.html)

The ability to filter an array to component values adds a fair bit of complexity and keeps us from being able to use some existing work (like the new CBOR Pointer) outright. We should think about whether this is required.

This does not attempt to add functions (such as length of array, something @c2bo mentioned they used in their prototype). Functions are actually somewhat difficult to represent in such a selector as a special case within CBOR, since a CBOR map can be keyed off of literally anything.

As specified (and as shown in examples), it is possible to have a root document of claims which cannot be reconstructed from the payloads and selectors. It is also possible to have an issuer release a claim and provide a selector into it which does not match when evaluated by the holder/verifier. We probably need to have opinions on these behaviors.