### PR TITLE
Editorial improvements draft 14

### DIFF
--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -341,8 +341,8 @@ Presentation Header Parameters SHOULD NOT contain values that are common
 across multiple presentations and SHOULD be unique to a single
 presentation and verifier.
 
-The Presentation Header MUST contain the same Algorithm
-protected header as the Issuer Header.  The Holder
+The Presentation Header MUST contain the same `alg` Header Parameter as
+the Issuer Header.  The Holder
 Presentation Algorithm Header Parameter MUST NOT be included.
 
 ### Presentation

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -500,8 +500,8 @@ payloads to serialize the JWP.
 ### Issuance Proof Verification
 
 Holder verification of the signature on issuance form is performed using
-the `Verify` operation from [@!I-D.irtf-cfrg-bbs-signatures, Section
-3.5.2].
+the `Verify` operation from
+[@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.2].
 
 This operation utilizes the issuer's public key as `PK`, the proof as
 `signature`, the Header octets as `header` and the array of
@@ -533,8 +533,8 @@ serialization and a zero-length string in compact serialization.
 ### Presentation Verification
 
 Verification of a presentation is done by the verifier using the
-`ProofVerify` operation from [@!I-D.irtf-cfrg-bbs-signatures, Section
-3.5.4].
+`ProofVerify` operation from
+[@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.4].
 
 This operation utilizes the issuer's public key as `PK`, the Issuer
 Header as `header`, the issuance proof as `signature`, the

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -264,7 +264,7 @@ between the parties.
 
 ### Holder Setup
 
-In order to support the protection of a presentation by a holder to a
+To support the protection of a presentation by a holder to a
 verifier, the holder MUST use a Holder Presentation Key during the
 issuance and the presentation of every Single Use JWP.  This Holder
 Presentation Key MUST be generated and used for only one JWP if
@@ -478,7 +478,7 @@ The `BBS` algorithm corresponds to a cipher suite identifier of
 The key used for the `BBS` algorithm is an elliptic curve-based key
 pair, specifically against the G_2 subgroup of a pairing friendly curve.
 Additional details on key generation can be found in
-[@!I-D.irtf-cfrg-bbs-signatures, Section 3.4].  The JWK and Cose Key
+[@!I-D.irtf-cfrg-bbs-signatures, Section 3.4].  The JWK and COSE Key
 Object representations of the key are detailed in
 [@!I-D.ietf-cose-bls-key-representations].
 
@@ -559,7 +559,7 @@ algorithm than the Issuer used to sign the issued form.
 
 Like the Single Use algorithm family, it also does not support
 unlinkability if the same JWP is presented multiple times and requires
-an individually issued JWP for each presentation in order to fully
+an individually issued JWP for each presentation to fully
 protect privacy.  When compared to the JWS approach, using a MAC
 requires less computation but can result in potentially larger
 presentation proof values.
@@ -574,7 +574,7 @@ authenticity of the issuer and holder.
 
 ### Holder Setup
 
-In order to support the protection of a presentation by a holder to a
+To support the protection of a presentation by a holder to a
 verifier, the holder MUST use a Holder Presentation Key during the
 issuance and the presentation of every MAC JWP.  This Holder
 Presentation Key MUST be generated and used for only one JWP if
@@ -810,7 +810,7 @@ should direct all requests for registration to the review mailing list.
 
 It is suggested that multiple Designated Experts be appointed who are
 able to represent the perspectives of different applications using this
-specification, in order to enable broadly informed review of
+specification, to enable broadly informed review of
 registration decisions.  In cases where a registration decision could be
 perceived as creating a conflict of interest for a particular Expert,
 that Expert should defer to the judgment of the other Experts.
@@ -819,7 +819,7 @@ that Expert should defer to the judgment of the other Experts.
 
 This specification establishes the IANA "JSON Web Proof Algorithms"
 registry, under the "JSON Object Signing and Encryption (JOSE)" registry
-group. The registry records values values of the JWP `alg` (algorithm)
+group. The registry records values of the JWP `alg` (algorithm)
 Header Parameter.  The registry records the algorithm name, the
 algorithm description, the algorithm usage locations, the implementation
 requirements, the change controller, and a reference to the
@@ -1074,7 +1074,7 @@ the final assigned value and remove this note before publication.]
 {{common-biblio.md}}
 {{series-draft-biblio.md}}
 
-# Example JWPs
+# JWP Examples
 
 The following examples use algorithms defined in JSON Proof Algorithms
 and also contain the keys used, so that implementations can validate
@@ -1167,7 +1167,7 @@ Figure: Presentation (SU-ES256, JSON, Compact Serialization)
 ## Example CBOR-Serialized Single-Use CPT
 
 This example is meant to mirror the prior compact serialization, using
-[RFC8392] (CWT) and claims from [@I-D.ietf-spice-oidc-cwt],
+[@RFC8392] (CWT) and claims from [@I-D.ietf-spice-oidc-cwt],
 illustrated using [@I-D.ietf-cbor-edn-literals] (EDN).
 
 To simplify this example, the same information is represented as the JPT
@@ -1183,7 +1183,7 @@ When signed and serialized, the CPT is represented by the following CBOR
 (in hex):
 
 <{{./fixtures/build/cpt-issuer-form.cbor.hex}}>
-Fixtures: Issued Form (SU-ES256, CBOR)
+Figure: Issued Form (SU-ES256, CBOR)
 
 The presented form, similarly to the issued form above, is made with the
 holder conveying the same parameters and the same set of selectively
@@ -1230,7 +1230,7 @@ address, and generates a proof.  That proof is represented in the
 following serialization:
 
 <{{./fixtures/build/bbs-presentation-compact.jwp.wrapped}}
-Figure: Presentation JWP (BBS, JSON, Compact serialization)
+Figure: Presentation JWP (BBS, JSON, Compact Serialization)
 
 ## Example MAC JWP
 
@@ -1382,7 +1382,7 @@ The BBS examples were generated using the library at
   domain separation.
 - Clarify how verifiers are to generate the Combined MAC Representation
   from available information.
-- Provider step-by-step instructions for verification of a presentation
+- Provide step-by-step instructions for verification of a presentation
 - Change Proof Key to Issuer Ephemeral Key and Presentation Key to
   Holder Presentation Key
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -478,7 +478,7 @@ The `BBS` algorithm corresponds to a cipher suite identifier of
 The key used for the `BBS` algorithm is an elliptic curve-based key
 pair, specifically against the G_2 subgroup of a pairing friendly curve.
 Additional details on key generation can be found in
-[@!I-D.irtf-cfrg-bbs-signatures, Section 3.4].  The JWK and COSE Key
+[@!I-D.irtf-cfrg-bbs-signatures, section 3.4].  The JWK and COSE Key
 Object representations of the key are detailed in
 [@!I-D.ietf-cose-bls-key-representations].
 
@@ -488,7 +488,7 @@ presentation proofs.
 ### Issuance
 
 Issuance is performed using the `Sign` operation from
-[@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.1].  This operation
+[@!I-D.irtf-cfrg-bbs-signatures, section 3.5.1].  This operation
 utilizes the issuer's BLS12-381 G2 key pair as `SK` and `PK`, along with
 desired Header octets as `header`, and the array of payload
 octet string as `messages`.
@@ -501,7 +501,7 @@ payloads to serialize the JWP.
 
 Holder verification of the signature on issuance form is performed using
 the `Verify` operation from
-[@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.2].
+[@!I-D.irtf-cfrg-bbs-signatures, section 3.5.2].
 
 This operation utilizes the issuer's public key as `PK`, the proof as
 `signature`, the Header octets as `header` and the array of
@@ -510,7 +510,7 @@ payload octets as `messages`.
 ### Presentation
 
 Derivation of a presentation is done by the holder using the `ProofGen`
-operation from [@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.3].
+operation from [@!I-D.irtf-cfrg-bbs-signatures, section 3.5.3].
 
 This operation utilizes the issuer's public key as `PK`, the Issuer
 Header as `header`, the issuance proof as `signature`, the
@@ -534,7 +534,7 @@ serialization and a zero-length string in compact serialization.
 
 Verification of a presentation is done by the verifier using the
 `ProofVerify` operation from
-[@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.4].
+[@!I-D.irtf-cfrg-bbs-signatures, section 3.5.4].
 
 This operation utilizes the issuer's public key as `PK`, the Issuer
 Header as `header`, the issuance proof as `signature`, the
@@ -1039,8 +1039,8 @@ Algorithm Analysis Documents(s):
 ## JSON Web Key Parameters Registry {#JWKParamReg}
 
 This section registers the following JWK parameter in the IANA "JSON Web
-Key Parameters" registry [@IANA.JOSE] established by Section 8.1 of
-[@!RFC7517].
+Key Parameters" registry [@IANA.JOSE] established by
+[@!RFC7517, section 8.1].
 
 ### Registry Contents {#JWKParamContents}
 
@@ -1055,7 +1055,7 @@ Key Parameters" registry [@IANA.JOSE] established by Section 8.1 of
 
 This section registers the following COSE_Key parameter in the IANA
 "COSE Key Common Parameters" registry [@IANA.COSE] established by
-Section 11.2 of [@!RFC9052].
+[@!RFC9052, section 11.2].
 
 ### Registry Contents {#COSEKeyParamContents}
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -217,7 +217,7 @@ registered in the IANA "JSON Web Proof Algorithms" registry established
 by this specification, or be a collision-resistant name for a JSON Web
 Proof Algorithm.
 
-As a CWK paramter, this value may also be an integer value.
+As a CWK parameter, this value may also be an integer value.
 The integer CBOR Label from the "JSON Web Proof Algorithms" registry
 SHOULD be used when one is available.
 
@@ -279,7 +279,7 @@ The issuer MUST determine an appropriate holder presentation algorithm
 corresponding to the holder presentation key.  If the holder and
 verifier cannot be assumed to know this algorithm is the appropriate
 choice for a given holder presentation key, this value MUST be conveyed
-in the `hpa` Issuer Header.
+in the `hpa` Issuer Header Parameter.
 
 ### Issuer Setup
 
@@ -595,7 +595,7 @@ The issuer MUST determine an appropriate holder presentation algorithm
 corresponding to the holder presentation key.  If the holder and
 verifier cannot be assumed to know this algorithm is the appropriate
 choice for a given holder presentation key, this value MUST be conveyed
-in the Holder Protected Algorithm Header Parameter.
+in the `hpa` Issuer Header Parameter.
 
 ### Issuer Setup
 
@@ -631,12 +631,12 @@ its 8-byte, network-ordered representation.  For example, the length of
 a 1,234-byte payload would have a length representation of
 `0x00 00 00 00 00 00 04 D2`.
 
-The holder will a unique key per payload value using a MAC, with the
-Shared Secret as the key and a generated binary value.  This binary
+The holder will derive a unique key per payload value using a MAC, with
+the Shared Secret as the key and a generated binary value.  This binary
 value is constructed by appending data into a single octet string:
 
 1. `0x82 67 70 61 79 6C 6F 61 64 1B`
-2. The zero indexed count of the payload slot
+2. The zero-indexed count of the payload slot
 
 The holder will also compute a corresponding MAC of each payload.  This
 MAC uses the unique key above and the payload octet string as the value.

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -76,7 +76,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 capitals, as shown here.
 
 The roles of "issuer", "holder", and "verifier" are used as defined by
-the VC Data Model [@VC-DATA-MODEL-2.0].  The term "presentation" is also
+the VC Data Model [@!VC-DATA-MODEL-2.0].  The term "presentation" is also
 used as defined by this source, but the term "credential" is avoided in
 this specification to minimize confusion with other definitions.
 
@@ -488,7 +488,7 @@ presentation proofs.
 ### Issuance
 
 Issuance is performed using the `Sign` operation from
-[@!I-D.irtf-cfrg-bbs-signatures, section 3.5.1].  This operation
+[@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.1].  This operation
 utilizes the issuer's BLS12-381 G2 key pair as `SK` and `PK`, along with
 desired Header octets as `header`, and the array of payload
 octet string as `messages`.
@@ -500,7 +500,7 @@ payloads to serialize the JWP.
 ### Issuance Proof Verification
 
 Holder verification of the signature on issuance form is performed using
-the `Verify` operation from [@!I-D.irtf-cfrg-bbs-signatures, section
+the `Verify` operation from [@!I-D.irtf-cfrg-bbs-signatures, Section
 3.5.2].
 
 This operation utilizes the issuer's public key as `PK`, the proof as
@@ -510,7 +510,7 @@ payload octets as `messages`.
 ### Presentation
 
 Derivation of a presentation is done by the holder using the `ProofGen`
-operation from [@!I-D.irtf-cfrg-bbs-signatures, section 3.5.3].
+operation from [@!I-D.irtf-cfrg-bbs-signatures, Section 3.5.3].
 
 This operation utilizes the issuer's public key as `PK`, the Issuer
 Header as `header`, the issuance proof as `signature`, the
@@ -780,7 +780,7 @@ the initial registrations:
 The following registration procedure is used for all the registries
 established by this specification.
 
-Values are registered on a Specification Required [@RFC5226] basis after
+Values are registered on a Specification Required [@!RFC8126] basis after
 a three-week review period on the <jose-reg-review@ietf.org> mailing
 list, on the advice of one or more Designated Experts.  However, to
 allow for the allocation of values prior to publication, the Designated
@@ -1402,7 +1402,7 @@ The BBS examples were generated using the library at
 - Update registry template for algorithms to account for integer CBOR
   labels
 - Restylize initial registry entries for readability
-- Defer BBS key definition to [@I-D.ietf-cose-bls-key-representations]
+- Defer BBS key definition to [@!I-D.ietf-cose-bls-key-representations]
 - Modify example generation to use `proof_key` and `presentation_key`
   names
 - Change `proof_jwk` to `proof_key` and `presentation_jwk` to

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -1345,6 +1345,9 @@ The BBS examples were generated using the library at
 - `MAC-H256` example no longer omits some components in signed inputs.
 - Align `SU-ES256` prose and fixtures for compact and CPT example
   payloads and disclosures
+- Clarified `alg` Header Parameter terminology.
+- Applied editorial corrections.
+- Normalized references and section citations.
 
 -13
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -1039,7 +1039,8 @@ Algorithm Analysis Documents(s):
 ## JSON Web Key Parameters Registry {#JWKParamReg}
 
 This section registers the following JWK parameter in the IANA "JSON Web
-Key Parameters" registry [@IANA.JOSE] established by [@RFC7517].
+Key Parameters" registry [@IANA.JOSE] established by Section 8.1 of
+[@!RFC7517].
 
 ### Registry Contents {#JWKParamContents}
 
@@ -1054,7 +1055,7 @@ Key Parameters" registry [@IANA.JOSE] established by [@RFC7517].
 
 This section registers the following COSE_Key parameter in the IANA
 "COSE Key Common Parameters" registry [@IANA.COSE] established by
-[@RFC9052].
+Section 11.2 of [@!RFC9052].
 
 ### Registry Contents {#COSEKeyParamContents}
 

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -84,7 +84,7 @@ this specification to minimize confusion with other definitions.
 
 The terms "JSON Web Signature (JWS)", "Base64url Encoding", "Header
 Parameter", "JOSE Header", "JWS Payload", "JWS Signature", and "JWS
-Protected Header" are defined by [@!RFC7515].
+Protected Header" are defined by [@!RFC7515, section 2].
 
 The terms "JSON Web Proof (JWP)", "JWP Payload", "JWP Proof", and "JWP
  Header" are defined by [@!I-D.ietf-jose-json-web-proof].

--- a/draft-ietf-jose-json-proof-algorithms.md
+++ b/draft-ietf-jose-json-proof-algorithms.md
@@ -258,9 +258,8 @@ JWP.  The fully-specified algorithm the holder must use for
 presentations is also included.  This algorithm MAY be different from
 the algorithm used by the issuer.
 
-The chosen algorithms MUST be asymmetric signing algorithms, so that
-each signature can be verified without sharing any private values
-between the parties.
+Issuers and holders MUST choose asymmetric signing algorithms, so each
+signature can be verified without sharing secrets between the parties.
 
 ### Holder Setup
 
@@ -341,9 +340,9 @@ Presentation Header Parameters SHOULD NOT contain values that are common
 across multiple presentations and SHOULD be unique to a single
 presentation and verifier.
 
-The Presentation Header MUST contain the same `alg` Header Parameter as
-the Issuer Header.  The Holder
-Presentation Algorithm Header Parameter MUST NOT be included.
+The Presentation Header MUST contain the same `alg` Header Parameter
+value as the Issuer Header.  It MUST NOT contain the `hpa` Header
+Parameter.
 
 ### Presentation
 
@@ -525,10 +524,10 @@ to be disclosed for later proof verification.
 The output of this operation is the presentation proof, as a single
 octet string.
 
-Presentation serialization leverages the two Headers and
-presentation proof, along with the disclosed payloads.  Non-disclosed
-payloads are represented with the absent value of `null` in CBOR
-serialization and a zero-length string in compact serialization.
+Presentation serialization leverages the two Headers and presentation
+proof, along with the disclosed payloads.  Encoding of disclosed and
+omitted payload slots follows the JWP serialization rules defined in
+[@!I-D.ietf-jose-json-web-proof].
 
 ### Presentation Verification
 
@@ -545,6 +544,9 @@ In addition, the `disclosed_indexes` scalar array is calculated from the
 payloads provided.  Values disclosed in the presented payloads have a
 zero-based index in this array, while the indices of absent payloads are
 omitted.
+
+If `ProofVerify` returns false, the presented JWP is invalid and the
+verifier rejects it.
 
 ## Message Authentication Code
 
@@ -1077,9 +1079,9 @@ the final assigned value and remove this note before publication.]
 
 # JWP Examples
 
-The following examples use algorithms defined in JSON Proof Algorithms
-and also contain the keys used, so that implementations can validate
-these samples.
+This section provides several sample JWPs, using algorithms defined
+above. The private keys are also included so that implementations can
+validate these samples.
 
 ## Example JSON-Serialized Single-Use JWP
 
@@ -1177,6 +1179,9 @@ example above, including the same public and private keys.
 <{{./fixtures/build/cpt-issuer-header.edn}}>
 Figure: Issuer Header (SU-ES256, CBOR)
 
+The payload values below are the same logical claims as in the JSON JPT
+example above, represented in EDN for the CBOR-based form.
+
 <{{./fixtures/template/cpt-issuer-payloads.edn}}>
 Figure: Issuer Payloads (as CBOR array)
 
@@ -1210,7 +1215,7 @@ Figure: BBS private key in JWK format
 
 There is no additional holder key necessary for presentation proofs.
 
-For the following protected header and array of payloads:
+For the following Issuer Header and array of payloads:
 
 <{{./fixtures/template/jpt-issuer-header.json}}
 Figure: Example Issuer Header
@@ -1348,6 +1353,7 @@ The BBS examples were generated using the library at
 - Clarified `alg` Header Parameter terminology.
 - Applied editorial corrections.
 - Normalized references and section citations.
+- Clarified BBS presentation serialization and example prose.
 
 -13
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -125,7 +125,7 @@ the payloads.
 
 ## Selective Disclosure
 
-While JWPs provide the underling structure for easily supporting
+While JWPs provide the underlying structure for easily supporting
 selective disclosure, JPTs and CPTs must go a step further to ensure
 that holders can effectively provide choice and consent on exactly what
 is being disclosed.  Software using JWPs or CPTs MUST know the mappings
@@ -137,14 +137,14 @@ NOT contain claims that are intended only for a specific verifier.
 
 ## Familiarity
 
-JPTs are intended to be as close to a JWT as possible in order to
+JPTs are intended to be as close to a JWT as possible to
 provide the simplest transition for any JWT-based system to add support
 for JPTs.  The same is true for CPTs and CWTs.
 
 Although there are some stark differences in the lifecycle of a JPT,
 from the application's perspective, the interface to a JPT can be made
 fairly similar: a JSON object containing a mix of required and optional
-claims with well-understood values.  Likewise, A CPT is a CBOR object
+claims with well-understood values.  Likewise, a CPT is a CBOR object
 containing a mix of required and optional claims with well-understood
 values.
 
@@ -219,7 +219,7 @@ The structure of the `cid` value is unspecified.  For JPTs, its value
 MUST be a case-sensitive string.  For CPTs, its value MUST be a binary
 string.  Use of this Header Parameter is OPTIONAL.
 
-The `cid` can be used similarly to a `kid` in order to ensure that it is
+The `cid` can be used similarly to a `kid` to ensure that it is
 possible to externally resolve and then verify that the correct list of
 claim names is being used when processing the payloads containing the
 claim values.
@@ -231,7 +231,7 @@ containing the signing key information, the `claims` key is also
 registered there as a convenient location for the claim names.
 
 When the claims array is transferred as a property in the Issuer Header,
-any variations of that array between JWP will be visible to the
+any variations of that array between JWPs will be visible to the
 verifier, and can leak information about the subject or provide an
 additional vector for linkability.  Given the privacy design
 considerations around linkability, it is RECOMMENDED that the claims are
@@ -391,7 +391,7 @@ The media type for a CBOR Proof Token (CPT) is `application/cpt`.
 ## Structured Syntax Suffix Registry
 
 This section registers the following entries in the IANA "Structured
-Syntax Suffix" registry [IANA.StructuredSuffix] in the manner described
+Syntax Suffix" registry [@IANA.StructuredSuffix] in the manner described
 in [@RFC6838].
 
 ### +jpt

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -112,16 +112,16 @@ a subtle vector for relying parties to collude and correlate one or more
 subjects across their usage.
 
 The principal tools to prevent this are data minimization and
-uniformity.  The data included SHOULD be minimized to remove potential
-correlation points.  The data SHOULD contain only values that are able
-to be selectively disclosed with consent or transformed by the proof
-algorithm when presented.
+uniformity.  Issuers and applications SHOULD minimize included data to
+remove potential correlation points.  Issuers SHOULD include only values
+that are able to be selectively disclosed with consent or transformed by
+the proof algorithm when presented.
 
 Any other data that is repeated across multiple JPTs or CPTs is
 externalized so that it is uniform across every issuance.  This includes
-preventing the use of optional Headers, dynamic mapping of claims to
-payloads, changes to how many payloads are included, and the ordering of
-the payloads.
+preventing use of optional Header Parameters, dynamic mapping of claims
+to payloads, changes to how many payloads are included, and the ordering
+of the payloads.
 
 ## Selective Disclosure
 
@@ -456,6 +456,8 @@ for his valuable contributions to this specification.
 
 - Applied editorial corrections.
 - Normalized references and section citations.
+- Clarified unlinkability guidance for data minimization and optional
+  Header Parameters.
 
 -13
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -260,12 +260,12 @@ represented as a CBOR value.
 ## Undisclosed
 
 The placeholder indicating that a payload was not disclosed is
-represented as described in [@!I-D.ietf-jose-json-web-proof, Section 6]
+represented as described in [@!I-D.ietf-jose-json-web-proof, section 6]
 (Serializations).
 
 # Example JPT and CPT
 
-See the examples in [@I-D.ietf-jose-json-proof-algorithms, Section A.1].
+See the examples in [@I-D.ietf-jose-json-proof-algorithms, section A.1].
 
 # Security Considerations {#security}
 
@@ -302,8 +302,8 @@ This section registers the following Header Parameter in the IANA
 ## JSON Web Key Parameters Registry {#JWKParamReg}
 
 This section registers the following JWK parameter in the IANA "JSON Web
-Key Parameters" registry [@IANA.JOSE] established by Section 8.1 of
-[@!RFC7517].
+Key Parameters" registry [@IANA.JOSE] established by
+[@!RFC7517, section 8.1].
 
 ### Registry Contents {#JWKParamContents}
 
@@ -318,7 +318,7 @@ Key Parameters" registry [@IANA.JOSE] established by Section 8.1 of
 
 This section registers the following COSE_Key parameter in the IANA
 "COSE Key Common Parameters" registry [@IANA.COSE] established by
-Section 11.2 of [@!RFC9052].
+[@!RFC9052, section 11.2].
 
 ### Registry Contents {#COSEKeyParamContents}
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -302,7 +302,8 @@ This section registers the following Header Parameter in the IANA
 ## JSON Web Key Parameters Registry {#JWKParamReg}
 
 This section registers the following JWK parameter in the IANA "JSON Web
-Key Parameters" registry [@IANA.JOSE] established by [@RFC7517].
+Key Parameters" registry [@IANA.JOSE] established by Section 8.1 of
+[@!RFC7517].
 
 ### Registry Contents {#JWKParamContents}
 
@@ -317,7 +318,7 @@ Key Parameters" registry [@IANA.JOSE] established by [@RFC7517].
 
 This section registers the following COSE_Key parameter in the IANA
 "COSE Key Common Parameters" registry [@IANA.COSE] established by
-[@RFC9052].
+Section 11.2 of [@!RFC9052].
 
 ### Registry Contents {#COSEKeyParamContents}
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -265,7 +265,7 @@ represented as described in [@!I-D.ietf-jose-json-web-proof, Section 6]
 
 # Example JPT and CPT
 
-See the examples in [@I-D.ietf-jose-json-proof-algorithms, section A.1].
+See the examples in [@I-D.ietf-jose-json-proof-algorithms, Section A.1].
 
 # Security Considerations {#security}
 
@@ -317,7 +317,7 @@ Key Parameters" registry [@IANA.JOSE] established by [@RFC7517].
 
 This section registers the following COSE_Key parameter in the IANA
 "COSE Key Common Parameters" registry [@IANA.COSE] established by
-[@RFC8152].
+[@RFC9052].
 
 ### Registry Contents {#COSEKeyParamContents}
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -119,7 +119,7 @@ algorithm when presented.
 
 Any other data that is repeated across multiple JPTs or CPTs is
 externalized so that it is uniform across every issuance.  This includes
-preventing the usage of optional Headers, dynamic mapping of claims to
+preventing the use of optional Headers, dynamic mapping of claims to
 payloads, changes to how many payloads are included, and the ordering of
 the payloads.
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -333,7 +333,7 @@ This section registers the following COSE_Key parameter in the IANA
 
 This section registers the following media type [@RFC2046] in the IANA
 "Media Types" registry [@IANA.MediaTypes] in the manner
-described in [@RFC6838].
+described in [@RFC6838, section 5.6].
 
 ### application/jpt {#jpt_media_type}
 
@@ -393,7 +393,7 @@ The media type for a CBOR Proof Token (CPT) is `application/cpt`.
 
 This section registers the following entries in the IANA "Structured
 Syntax Suffix" registry [@IANA.StructuredSuffix] in the manner described
-in [@RFC6838].
+in [@RFC6838, section 6.2].
 
 ### +jpt
 

--- a/draft-ietf-jose-json-proof-token.md
+++ b/draft-ietf-jose-json-proof-token.md
@@ -452,6 +452,11 @@ for his valuable contributions to this specification.
 
 [[ To be removed from the final specification ]]
 
+-14
+
+- Applied editorial corrections.
+- Normalized references and section citations.
+
 -13
 
 - Examples are now built deterministically (using RFC 6979 deterministic

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -706,7 +706,7 @@ representation parallel to the JWS JSON serialization is defined.
 
  JWP CBOR Serialization provides a compact CBOR-based encoding suitable
 for constrained environments.  Its design closely parallels COSE_Sign1
-[@RFC9338].
+in [@RFC9052, section 4.2].
 
 ## Compact Serialization {#CompactSerialization}
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -400,8 +400,8 @@ The `iek` (Issuer Ephemeral Key) represents the public key used by the
 issuer for indirect signatures within certain algorithms. This is an
 ephemeral key that MUST be unique for each issued JWP.
 
-This Header Parameter is references a JSON Web Key (JWK) public key
-value when represented as a JSON-formatted Header, and a COSE Key Object
+This Header Parameter references a JSON Web Key (JWK) public key value
+when represented as a JSON-formatted Header, and a COSE Key Object
 when represented as a CBOR-formatted Header.
 
 It MUST contain only public key parameters and SHOULD contain only the
@@ -422,8 +422,8 @@ The issuer MUST validate that the holder has possession of this key
 through a trusted mechanism, such as requiring the signature of a unique
 nonce value from the holder before issuing the JWP.
 
-This Header Parameter is references a JSON Web Key (JWK) public key
-value when represented as a JSON-formatted Header, and a COSE Key Object
+This Header Parameter references a JSON Web Key (JWK) public key value
+when represented as a JSON-formatted Header, and a COSE Key Object
 when represented as a CBOR-formatted Header.
 
 It MUST contain only public key parameters and SHOULD contain only the
@@ -509,7 +509,7 @@ Use of this Header Parameter is OPTIONAL.
 ## Public Header Parameter Names {#PublicHeaderParameterName}
 
 Additional Header Parameter names can be defined by those using JWPs.
-However, in order to prevent collisions, any new Header Parameter name
+However, to prevent collisions, any new Header Parameter name
 should either be registered in the IANA "JSON Web Proof Header
 Parameters" registry established by (#HdrReg) or be a Public Name (a
 value that contains a Collision-Resistant Name).  In each case, the
@@ -614,7 +614,7 @@ proof value will always be updated to add integrity protection of the
 Presentation Header along with the necessary cryptographic statements to
 verify the presented JWP.
 
-When supported by the underling JPA, a single issued JWP can be used to
+When supported by the underlying JPA, a single issued JWP can be used to
 safely generate multiple presented JWPs without becoming correlatable.
 
 A JWP may also be single use, where an issued JWP can only be used once
@@ -626,7 +626,7 @@ issued JWPs can be retrieved easily.
 ### Presentation Header {#presentation-header}
 
 The presented form of a JWP MUST contain a Presentation Header.  It is
-added by the holder and MUST be integrity protected by the underling
+added by the holder and MUST be integrity protected by the underlying
 JPA.
 
 This Header is used to ensure that a presented JWP cannot be replayed
@@ -813,7 +813,7 @@ Tagged_CBOR_JWP_Presented = #6.yyy (CBOR_JWP_Presented)
 
 ```
 
-Figure 1: CDDL [RFC8610] for CBOR Serializations.
+Figure 1: CDDL [@RFC8610] for CBOR Serializations.
 
 # Encrypted JSON Web Proofs
 
@@ -909,7 +909,7 @@ should direct all requests for registration to the review mailing list.
 
 It is suggested that multiple Designated Experts be appointed who are
 able to represent the perspectives of different applications using this
-specification, in order to enable broadly informed review of
+specification, to enable broadly informed review of
 registration decisions.  In cases where a registration decision could be
 perceived as creating a conflict of interest for a particular Expert,
 that Expert should defer to the judgment of the other Experts.
@@ -1131,7 +1131,7 @@ is a JWP using the JWP Compact Serialization.
 ### Registry Contents {#SuffixContents}
 
 This section registers the following entries in the IANA "Structured
-Syntax Suffix" registry [IANA.StructuredSuffix] in the manner described
+Syntax Suffix" registry [@IANA.StructuredSuffix] in the manner described
 in [@RFC6838].
 
 #### The +jwp Structured Syntax Suffix

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -346,9 +346,9 @@ corresponds to the IANA "CoAP Content-Formats" registry
 [@IANA.CoAP.Formats], which describes the corresponding media type, as
 described in [@!RFC9596, section 2].
 
-Per [@!RFC2045], all media type values, subtype values, and parameter
-names are case insensitive.  However, parameter values are case
-sensitive unless otherwise specified for the specific parameter.
+Per [@!RFC2045, section 5.1], all media type values, subtype values,
+and parameter names are case insensitive.  However, parameter values are
+case sensitive unless otherwise specified for the specific parameter.
 
 To keep messages compact in common situations, it is RECOMMENDED that
 producers omit an "application/" prefix of a media type value in a `typ`
@@ -366,8 +366,7 @@ can also be used by applications, including those using the `+jwp` media
 type structured syntax suffix.
 
 It is RECOMMENDED that the `typ` Header Parameter be used for explicit
-typing, in parallel to the recommendations in Section 3.11 of
-[@RFC8725].
+typing, in parallel to the recommendations in [@RFC8725, section 3.11].
 
 ### "crit" (Critical) Header Parameter {#critDef}
 
@@ -1070,8 +1069,8 @@ This section registers the Header Parameters defined in
 
 This section registers the `application/jwp` media type [@RFC2046] in
 the IANA "Media Types" registry [@IANA.MediaTypes] in the manner
-described in [@RFC6838], which can be used to indicate that the content
-is a JWP using the JWP Compact Serialization.
+described in [@RFC6838, section 5.6], which can be used to indicate
+that the content is a JWP using the JWP Compact Serialization.
 
 #### The application/jwp Media Type
 
@@ -1132,7 +1131,7 @@ is a JWP using the JWP Compact Serialization.
 
 This section registers the following entries in the IANA "Structured
 Syntax Suffix" registry [@IANA.StructuredSuffix] in the manner described
-in [@RFC6838].
+in [@RFC6838, section 6.2].
 
 #### The +jwp Structured Syntax Suffix
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -122,7 +122,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 capitals, as shown here.
 
 The roles of "issuer", "holder", and "verifier" are used as defined by
-the VC Data Model [@VC-DATA-MODEL-2.0].  The term "presentation" is also
+the VC Data Model [@!VC-DATA-MODEL-2.0].  The term "presentation" is also
 used as defined by this source, but the term "credential" is avoided in
 this specification to minimize confusion with other definitions.
 
@@ -170,7 +170,7 @@ any algorithm-specific capabilities.
 
 To fully support the newer privacy primitives, JWP utilizes the three
 roles of issuer, holder, and verifier, as defined by the VC Data Model
-[@VC-DATA-MODEL-2.0].  There are also two forms of a JWP: the issued
+[@!VC-DATA-MODEL-2.0].  There are also two forms of a JWP: the issued
 form created by an issuer for a holder, and the presented form created
 by a holder for a verifier.
 
@@ -237,7 +237,7 @@ processing MUST reject messages if two Headers with the same parameter
 label are encountered. JSON processing SHOULD reject messages received
 with the same parameter label, but MAY instead represent only the
 lexically last member with that label, as specified in Section 15.12
-("The JSON Object") of ECMAScript 5.1 [@ECMAScript]. JSON processing
+("The JSON Object") of ECMAScript 5.1 [@!ECMAScript]. JSON processing
 MUST take one of these two approaches with regards to encountering
 duplicate Header Parameter labels.
 
@@ -346,7 +346,7 @@ corresponds to the IANA "CoAP Content-Formats" registry
 [@IANA.CoAP.Formats], which describes the corresponding media type, as
 described in [@!RFC9596].
 
-Per [@RFC2045], all media type values, subtype values, and parameter
+Per [@!RFC2045], all media type values, subtype values, and parameter
 names are case insensitive.  However, parameter values are case
 sensitive unless otherwise specified for the specific parameter.
 
@@ -813,7 +813,7 @@ Tagged_CBOR_JWP_Presented = #6.yyy (CBOR_JWP_Presented)
 
 ```
 
-Figure 1: CDDL [@RFC8610] for CBOR Serializations.
+Figure 1: CDDL [@!RFC8610] for CBOR Serializations.
 
 # Encrypted JSON Web Proofs
 
@@ -879,7 +879,7 @@ Notes to be expanded:
 The following registration procedure is used for all the registries
 established by this specification.
 
-Values are registered on a Specification Required [@RFC5226] basis after
+Values are registered on a Specification Required [@!RFC8126] basis after
 a three-week review period on the jose-reg-review@ietf.org mailing list,
 on the advice of one or more Designated Experts.  However, to allow for
 the allocation of values prior to publication, the Designated Experts

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -341,10 +341,13 @@ parameter is ignored by JWP implementations; any processing of this
 parameter is performed by the JWP application.  Use of this Header
 Parameter is OPTIONAL.
 
-For COSE-formatted Headers, `typ` MAY instead be an integer value that
-corresponds to the IANA "CoAP Content-Formats" registry
-[@IANA.CoAP.Formats], which describes the corresponding media type, as
-described in [@!RFC9596, section 2].
+When `typ` is used for a JSON-formatted Header, its value is a string
+containing a media type.
+
+When `typ` is used for a CBOR-formatted Header, its value MAY also be
+an integer from the IANA "CoAP Content-Formats" registry
+[@IANA.CoAP.Formats].  The integer value identifies the corresponding
+media type, as described in [@!RFC9596, section 2].
 
 Per [@!RFC2045, section 5.1], all media type values, subtype values,
 and parameter names are case insensitive.  However, parameter values are
@@ -413,7 +416,7 @@ implementations.
 
 ### "hpk" (Holder Presentation Key) Header Parameter {#holder_presentation_keyDef}
 
-The `hpk` (Holder Presentation Key) represents the public key with
+The `hpk` (Holder Presentation Key) represents the public key used with
 certain algorithms, and is used by the holder for proof of possession
 and integrity protection of the Presentation Header.
 
@@ -632,9 +635,10 @@ This Header is used to ensure that a presented JWP cannot be replayed
 and is cryptographically bound to the verifier it was presented to.
 
 While there are not any required Header Parameters in the Presentation
-Header, it MUST contain one or Header Parameters that uniquely identify
-the presented JWP to both the holder and verifier.  For example, Header
-Parameters that would satisfy this requirement include `nonce` and `aud`.
+Header, it MUST contain one or more Header Parameters that uniquely
+identify the presented JWP to both the holder and verifier.  For
+example, Header Parameters that would satisfy this requirement include
+`nonce` and `aud`.
 
 ### Presentation Payloads
 
@@ -704,7 +708,7 @@ encoding of a JWP in URL-safe characters.  Its design closely parallels
 the JWS Compact Serialization in [@RFC7515, section 7.1].  No
 representation parallel to the JWS JSON serialization is defined.
 
- JWP CBOR Serialization provides a compact CBOR-based encoding suitable
+The JWP CBOR Serialization provides a compact CBOR-based encoding suitable
 for constrained environments.  Its design closely parallels COSE_Sign1
 in [@RFC9052, section 4.2].
 
@@ -763,7 +767,7 @@ The CBOR serialization provides a compact binary representation of a
 JWP.  The serialization consists of two arrays, representing issued and
 presented forms.
 
-The Headers MUST be CBOR formatted for CBOR serialization.
+Implementations using CBOR Serialization MUST encode Headers in CBOR.
 This includes both the Issuer Header and Presentation Header in the
 presented form.
 
@@ -897,7 +901,7 @@ Registration requests that are undetermined for a period longer than 21
 days can be brought to the IESG's attention (using the iesg@ietf.org
 mailing list) for resolution.
 
-Criteria that should be applied by the Designated Experts includes
+Criteria that should be applied by the Designated Experts include
 determining whether the proposed registration duplicates existing
 functionality, whether it is likely to be of general applicability or
 useful only for a single application, and whether the registration
@@ -934,9 +938,9 @@ Header Parameter Name:
 Header Parameter JSON Label:
 : The string label requested within a JSON context. (e.g., `kid`).
   Because a core goal of this specification is for the resulting
-  representations to be compact, it is RECOMMENDED that the label be
+  representations to be compact, it is recommended that the label be
   short -- not to exceed 8 characters without a compelling reason to do
-  so. This label is case sensitive, and it is RECOMMENDED to avoid
+  so. This label is case sensitive, and it is recommended to avoid
   upper-case characters. Labels may not match another registered names
   in a case-insensitive manner unless the Designated Experts state that
   there is a compelling reason to allow an exception. This registry
@@ -1185,6 +1189,9 @@ for their valuable contributions to this specification.
 - Applied editorial corrections.
 - Normalized references and section citations.
 - Corrected the `COSE_Sign1` reference.
+- Clarified JSON-formatted and CBOR-formatted `typ` Header Parameter
+  values.
+- Clarified CBOR Serialization requirements for Header encoding.
 
 -13
 

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -850,7 +850,7 @@ or convention, in which case the `cty` value MAY be omitted.
 
 In some contexts, it is useful to make statements about payloads which
 are not themselves contained within the JWP, similar to "Detached
-Content" in JWS (Appendix F of [@RFC7515]).
+Content" in JWS [@RFC7515, section F].
 
 For this purpose, the compact, JSON and CBOR serializations allow for
 all payload slots to be omitted from a serialized form. While this is a

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -344,7 +344,7 @@ Parameter is OPTIONAL.
 For COSE-formatted Headers, `typ` MAY instead be an integer value that
 corresponds to the IANA "CoAP Content-Formats" registry
 [@IANA.CoAP.Formats], which describes the corresponding media type, as
-described in [@!RFC9596].
+described in Section 2 of [@!RFC9596].
 
 Per [@!RFC2045], all media type values, subtype values, and parameter
 names are case insensitive.  However, parameter values are case
@@ -463,7 +463,7 @@ specific.
 
 The `iss` value is a case-sensitive string containing a StringOrURI
 value.  Its definition is intentionally parallel to the `iss` claim
-defined in [@!RFC7519].
+defined in Section 4.1.1 of [@!RFC7519].
 
 Use of this Header Parameter is OPTIONAL.
 
@@ -484,7 +484,7 @@ string containing a StringOrURI value.
 The interpretation of audience values is application specific.
 
 Its definition is intentionally parallel to the `aud` claim defined in
-[@!RFC7519].
+Section 4.1.3 of [@!RFC7519].
 
 Use of this Header Parameter is OPTIONAL.
 
@@ -702,8 +702,8 @@ composed of multiple octet strings).
 
 The JWP Compact Serialization provides a JSON-based, space-efficient
 encoding of a JWP in URL-safe characters.  Its design closely parallels
-the JWS Compact Serialization [@RFC7515].  No representation parallel to
-the JWS JSON serialization is defined.
+the JWS Compact Serialization in Section 7.1 of [@RFC7515].  No
+representation parallel to the JWS JSON serialization is defined.
 
  JWP CBOR Serialization provides a compact CBOR-based encoding suitable
 for constrained environments.  Its design closely parallels COSE_Sign1
@@ -827,8 +827,9 @@ Encrypted JWPs is identical to the processing of other JWEs.
 For a JWP with JSON-formatted Headers, an Encrypted JWP is a JWE
 [@!RFC7516] with a JWP in Compact Serialization as its plaintext value.
 For a JWP with CBOR-formatted Headers, an Encrypted JWP should use
-`COSE_Encrypt0` or `COSE_Encrypt` [@!RFC9052] with the CBOR
-Serialization as its plaintext.
+`COSE_Encrypt0` (Section 5.2 of [@!RFC9052]) or `COSE_Encrypt`
+(Section 5.1 of [@!RFC9052]) with the CBOR Serialization as its
+plaintext.
 
 The `cty` (content type) JWE/COSE Header Parameter is used to indicate
 that the content of the JWE is a JWP.  The `cty` value of the JWE/COSE
@@ -850,7 +851,7 @@ or convention, in which case the `cty` value MAY be omitted.
 
 In some contexts, it is useful to make statements about payloads which
 are not themselves contained within the JWP, similar to "Detached
-Content" in JWS [@RFC7515].
+Content" in JWS (Appendix F of [@RFC7515]).
 
 For this purpose, the compact, JSON and CBOR serializations allow for
 all payload slots to be omitted from a serialized form. While this is a

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -341,8 +341,8 @@ parameter is ignored by JWP implementations; any processing of this
 parameter is performed by the JWP application.  Use of this Header
 Parameter is OPTIONAL.
 
-For COSE-formatted Headers, `typ` MAY also instead be an integer value
-which corresponds to the IANA "CoAP Content-Formats" registry
+For COSE-formatted Headers, `typ` MAY instead be an integer value that
+corresponds to the IANA "CoAP Content-Formats" registry
 [@IANA.CoAP.Formats], which describes the corresponding media type, as
 described in [@!RFC9596].
 
@@ -416,7 +416,7 @@ implementations.
 
 The `hpk` (Holder Presentation Key) represents the public key with
 certain algorithms, and is used by the holder for proof of possession
-and integrity protection of the Presented Header.
+and integrity protection of the Presentation Header.
 
 The issuer MUST validate that the holder has possession of this key
 through a trusted mechanism, such as requiring the signature of a unique
@@ -765,8 +765,8 @@ JWP.  The serialization consists of two arrays, representing issued and
 presented forms.
 
 The Headers MUST be CBOR formatted for CBOR serialization.
-This includes both the issued and Presented Headers in the presented
-form.
+This includes both the Issuer Header and Presentation Header in the
+presented form.
 
 The issued form consists of a three-element array, while the presented
 form consists of a four-element array.

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -687,8 +687,8 @@ The proof of a presented JWP will always be different than the issued
 proof.  At a minimum, it MUST be updated to include protection of the
 added Presentation Header.
 
-Algorithms SHOULD generate an un-correlatable presentation proof in
-order to support multiple presentations from a single issued JWP.
+Algorithms SHOULD generate presentation proofs that preserve
+unlinkability across multiple presentations from a single issued JWP.
 
 The algorithm is responsible for representing selective disclosure of
 payloads in a presented proof. If multiple octet strings are

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -273,7 +273,7 @@ IANA or another party, but are expected to only be used for testing or
 in closed environments.
 
 These classes of Header Parameters are intentionally parallel to those
-in Section 4 of [@RFC7515].
+in [@RFC7515, section 4].
 
 ## Registered Header Parameter Labels {#RegisteredHeaderParameterLabels}
 
@@ -344,7 +344,7 @@ Parameter is OPTIONAL.
 For COSE-formatted Headers, `typ` MAY instead be an integer value that
 corresponds to the IANA "CoAP Content-Formats" registry
 [@IANA.CoAP.Formats], which describes the corresponding media type, as
-described in Section 2 of [@!RFC9596].
+described in [@!RFC9596, section 2].
 
 Per [@!RFC2045], all media type values, subtype values, and parameter
 names are case insensitive.  However, parameter values are case
@@ -463,7 +463,7 @@ specific.
 
 The `iss` value is a case-sensitive string containing a StringOrURI
 value.  Its definition is intentionally parallel to the `iss` claim
-defined in Section 4.1.1 of [@!RFC7519].
+defined in [@!RFC7519, section 4.1.1].
 
 Use of this Header Parameter is OPTIONAL.
 
@@ -484,7 +484,7 @@ string containing a StringOrURI value.
 The interpretation of audience values is application specific.
 
 Its definition is intentionally parallel to the `aud` claim defined in
-Section 4.1.3 of [@!RFC7519].
+[@!RFC7519, section 4.1.3].
 
 Use of this Header Parameter is OPTIONAL.
 
@@ -702,7 +702,7 @@ composed of multiple octet strings).
 
 The JWP Compact Serialization provides a JSON-based, space-efficient
 encoding of a JWP in URL-safe characters.  Its design closely parallels
-the JWS Compact Serialization in Section 7.1 of [@RFC7515].  No
+the JWS Compact Serialization in [@RFC7515, section 7.1].  No
 representation parallel to the JWS JSON serialization is defined.
 
  JWP CBOR Serialization provides a compact CBOR-based encoding suitable
@@ -827,9 +827,8 @@ Encrypted JWPs is identical to the processing of other JWEs.
 For a JWP with JSON-formatted Headers, an Encrypted JWP is a JWE
 [@!RFC7516] with a JWP in Compact Serialization as its plaintext value.
 For a JWP with CBOR-formatted Headers, an Encrypted JWP should use
-`COSE_Encrypt0` (Section 5.2 of [@!RFC9052]) or `COSE_Encrypt`
-(Section 5.1 of [@!RFC9052]) with the CBOR Serialization as its
-plaintext.
+`COSE_Encrypt0` [@!RFC9052, section 5.2] or `COSE_Encrypt`
+[@!RFC9052, section 5.1] with the CBOR Serialization as its plaintext.
 
 The `cty` (content type) JWE/COSE Header Parameter is used to indicate
 that the content of the JWE is a JWP.  The `cty` value of the JWE/COSE

--- a/draft-ietf-jose-json-web-proof.md
+++ b/draft-ietf-jose-json-web-proof.md
@@ -1180,6 +1180,12 @@ for their valuable contributions to this specification.
 
 [[ To be removed from the final specification ]]
 
+-14
+
+- Applied editorial corrections.
+- Normalized references and section citations.
+- Corrected the `COSE_Sign1` reference.
+
 -13
 
 - Examples are now built deterministically (using RFC 6979 deterministic


### PR DESCRIPTION
An editorial pass including:

- tightening language (e.g. dropping 'in order to')
- correcting a few malformed references (specifically, line wrapping within a reference)
- evaluating the normative/informative referencing, and making sure each document is consistent
- refining references to point to particular sections/appendices when appropriate
- fix reference to COSE_Sign1, which was pointing to the countersignatures RFC